### PR TITLE
Use `0.x` as the `mdn-browser-compat-data` version specifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     },
     "homepage": "https://github.com/mdn/browser-compat-toolkit",
     "devDependencies": {
-        "mdn-browser-compat-data": "^0.0.31",
         "eslint": "^4.19.0",
         "eslint-config-standard": "^11.0.0",
         "eslint-plugin-import": "^2.9.0",
         "eslint-plugin-node": "^6.0.1",
         "eslint-plugin-promise": "^3.7.0",
         "eslint-plugin-standard": "^3.0.1",
+        "mdn-browser-compat-data": "0.x",
         "webpack": "^4.1.1",
         "webpack-cli": "^2.0.12"
     }


### PR DESCRIPTION
This synchronises the used version specifier [with KumaScript](https://github.com/mdn/kumascript/blob/d94af396c6b8c80248b0e159c33f46287ee3556e/package.json#L30) (required for https://github.com/mdn/kumascript/pull/716): https://github.com/mdn/browser-compat-toolkit/blob/d94af396c6b8c80248b0e159c33f46287ee3556e/package.json#L30
