### PR TITLE
Create TypeScript Definition File

### DIFF
--- a/src/renderers/index.d.ts
+++ b/src/renderers/index.d.ts
@@ -1,0 +1,16 @@
+/*!
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+type CompatData = typeof import('mdn-browser-compat-data')[any]
+
+interface Configuration {
+  query: string
+  depth?: number
+  forMDNURL?: boolean,
+  strings?: Record<string, string>
+}
+
+export function mdnFeatureTable (compatData: CompatData, configuration: Configuration): string


### PR DESCRIPTION
This PR adds a TypeScript definition file to be able to use this in a TypeScript project (or to get intellisense in Visual Studio Code).

See also mdn/browser-compat-data#2308